### PR TITLE
GERDA specific modification of fieldgen

### DIFF
--- a/deps/src/mjd_siggen/mjd_fieldgen.c
+++ b/deps/src/mjd_siggen/mjd_fieldgen.c
@@ -469,7 +469,8 @@ int main(int argc, char **argv)
 	  v[0][z][r] = v[1][z][r] = BV;  // at the bias voltage
 	}
 	// inside (point) contact, with optional bulletization:
-	else if (z <= LC && r <= rrc[z]) {
+	else if ((z <= LC && r <= rrc[z]) ||
+                 (z == 0 && r < RO-WO)) {   // special case for GERDA, wrap to ditch
 	  bulk[z][r] = -1;                // value of v[*][z][r] is fixed...
 	  v[0][z][r] = v[1][z][r] = 0;    // at zero volts
 	  /* radial edge of inside contact; if the PC radius is not in the middle
@@ -915,7 +916,8 @@ int main(int argc, char **argv)
 	  v[0][z][r] = v[1][z][r] = 0.0;   // to zero
 	}
 	// inside (point) contact:
-	else if (z <= LC && r <= rrc[z]) {
+	else if ((z <= LC && r <= rrc[z]) ||
+                 (z == 0 && r < RO-WO)) {   // special case for GERDA, wrap to ditch
 	  bulk[z][r] = -1;                 // value of v[*][z][r] is fixed...
 	  v[0][z][r] = v[1][z][r] = 1.0;   // to 1.0
 	  // radial edge of inside contact:


### PR DESCRIPTION
This modification moves the p+ contact up to the ditch/groove that was not true for coax detectors before:
![example_coax](https://user-images.githubusercontent.com/4508364/32829169-8ef5282c-c9f1-11e7-8a8d-6a5c1ec8644e.png)

It is GERDA specific so this version will not be part of SigGen.
Maybe it should be a separate branch but it should go in the main repository.
@oschulz what do you think?
