### PR TITLE
Bump minor version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MJDSigGen"
 uuid = "0b925020-e659-485c-98dd-189633cb4be4"
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 BinDeps = "9e28174c-4ba2-5203-b857-d8d62c4213ee"


### PR DESCRIPTION
There's an argument to bump the major version to 1.0, but since 0.x.x counts as development version anyway I think bumping the minor should be ok for now. Also, I'd like to use the new version of the package a bit to see where issues lie, before we go over to v1.0.